### PR TITLE
Restore EXCLUDE_NAMES filtering, fix mobile menu close alignment, improve meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,19 +1,23 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-Hant-TW">
 
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>KCouper</title>
-  <meta name="description" content="KFC coupon" />
+  <meta name="description" content="KCouper 整理最新肯德基 (KFC) 優惠券與優惠碼，讓你用最划算的價格享受美味炸雞。每日更新，快速查詢可用的優惠組合。" />
   <meta name="author" content="Adler Au" />
 
-  <meta property="og:title" content="KCouper" />
-  <meta property="og:description" content="KFC coupon" />
+  <meta property="og:site_name" content="KCouper" />
+  <meta property="og:title" content="KCouper - 省錢吃肯德基 | 最新 KFC 優惠券整理" />
+  <meta property="og:description" content="KCouper 整理最新肯德基 (KFC) 優惠券與優惠碼，讓你用最划算的價格享受美味炸雞。每日更新，快速查詢可用的優惠組合。" />
   <meta property="og:type" content="website" />
+  <meta property="og:locale" content="zh_TW" />
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@KCouper" />
+  <meta name="twitter:title" content="KCouper - 省錢吃肯德基 | 最新 KFC 優惠券整理" />
+  <meta name="twitter:description" content="KCouper 整理最新肯德基 (KFC) 優惠券與優惠碼，讓你用最划算的價格享受美味炸雞。每日更新。" />
 
   <!-- Preload coupon and single item data -->
   <script src="/coupon.js" defer></script>

--- a/script/gatherer/coupon.py
+++ b/script/gatherer/coupon.py
@@ -13,6 +13,11 @@ COUPON_RANGES = (
     _cs.strip().split('-')
     for _cs in os.getenv('COUPON_RANGES').split(',')
 )
+EXCLUDE_NAMES = frozenset(
+    _name.strip()
+    for _name in os.getenv('EXCLUDE_NAMES', '').split(',')
+    if _name.strip()
+)
 
 
 def normalize_name(name: str) -> str:
@@ -37,6 +42,8 @@ def convert_coupon_data(data: dict, coupon_code: str):
     price = detail['Original_Price']
     for food in detail['Details']:
         main_item = food['MList'][0]
+        if normalize_name(main_item['Name']) in EXCLUDE_NAMES:
+            continue
         item = {
             'name': normalize_name(main_item['Name']),
             'count': food['MinCount'],
@@ -45,6 +52,8 @@ def convert_coupon_data(data: dict, coupon_code: str):
         }
         price += main_item['MListPrice'] * food['MinCount']
         for flavor in food['MList'][1:]:
+            if normalize_name(flavor['Name']) in EXCLUDE_NAMES:
+                continue
             item['flavors'].append({
                 'name': normalize_name(flavor['Name']),
                 'addition_price': flavor['AddPrice'],

--- a/script/gatherer/coupon.py
+++ b/script/gatherer/coupon.py
@@ -16,7 +16,6 @@ COUPON_RANGES = (
 EXCLUDE_NAMES = frozenset(
     _name.strip()
     for _name in os.getenv('EXCLUDE_NAMES', '').split(',')
-    if _name.strip()
 )
 
 
@@ -42,20 +41,22 @@ def convert_coupon_data(data: dict, coupon_code: str):
     price = detail['Original_Price']
     for food in detail['Details']:
         main_item = food['MList'][0]
-        if normalize_name(main_item['Name']) in EXCLUDE_NAMES:
+        main_name = normalize_name(main_item['Name'])
+        if main_name in EXCLUDE_NAMES:
             continue
         item = {
-            'name': normalize_name(main_item['Name']),
+            'name': main_name,
             'count': food['MinCount'],
             'addition_price': main_item['AddPrice'],
             'flavors': [],
         }
         price += main_item['MListPrice'] * food['MinCount']
         for flavor in food['MList'][1:]:
-            if normalize_name(flavor['Name']) in EXCLUDE_NAMES:
+            flavor_name = normalize_name(flavor['Name'])
+            if flavor_name in EXCLUDE_NAMES:
                 continue
             item['flavors'].append({
-                'name': normalize_name(flavor['Name']),
+                'name': flavor_name,
                 'addition_price': flavor['AddPrice'],
             })
         items.append(item)

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -57,7 +57,6 @@ const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Con
       <SheetOverlay />
       <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
         {children}
-        {/* h-7 box matches the text-lg title line-height at the same p-6 offset, keeping the X centered on the header row */}
         <SheetPrimitive.Close className="absolute right-6 top-6 flex h-7 w-7 items-center justify-center rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
           <X className="h-5 w-5" />
           <span className="sr-only">Close</span>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -57,8 +57,9 @@ const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Con
       <SheetOverlay />
       <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
         {children}
-        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
-          <X className="h-4 w-4" />
+        {/* h-7 box matches the text-lg title line-height at the same p-6 offset, keeping the X centered on the header row */}
+        <SheetPrimitive.Close className="absolute right-6 top-6 flex h-7 w-7 items-center justify-center rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+          <X className="h-5 w-5" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>


### PR DESCRIPTION
## Summary

包含三項修正/改進（詳細背景見 #16）：

1. **恢復 `EXCLUDE_NAMES` 過濾**：讓環保餐具選項與醬料（`不需刀叉及手套`、`響應環保不需湯匙`、`糖醋醬` 等）不再進入優惠券資料。過濾邏輯在 e4f2a38 改用新 API 收集資料時遺失，`.env` 的 `EXCLUDE_NAMES` 從那之後就沒有作用了。
2. **修正手機版選單關閉按鈕對齊**：X 按鈕原本使用 `right-4 top-4`，但 Sheet 內容是 `p-6`，導致 X 偏高且超出內容邊界。改為 `right-6 top-6` 的 `h-7` flex box，與「選單」標題行高一致，垂直置中對齊（已於 390×844 viewport 驗證：標題與 X 中心皆為 y=38px）。
3. **改進 SEO / 社群分享 meta**：`<html lang>` 改為 `zh-Hant-TW`，補上在地化 description、`og:site_name`、`og:locale` 與 twitter title/description。

Closes #16

## 截圖

### 優惠券資料（以 26844 為例）

| Before | After |
|---|---|
| ![before-data](https://raw.githubusercontent.com/eryet/KCouper/pr-assets/assets/before-data.png) | ![after-data](https://raw.githubusercontent.com/eryet/KCouper/pr-assets/assets/after-data.png) |

「不需刀叉及手套」不再出現在餐點內容中，價格與折數不受影響。

### 手機版選單關閉按鈕

| Before | After |
|---|---|
| ![before-x](https://raw.githubusercontent.com/eryet/KCouper/pr-assets/assets/before-x.png) | ![after-x](https://raw.githubusercontent.com/eryet/KCouper/pr-assets/assets/after-x.png) |

X 由偏高、超出內容右緣，改為與「選單」標題垂直置中、與內容右緣切齊。

## Changes

- `script/gatherer/coupon.py`
  - 重新從環境變數讀取 `EXCLUDE_NAMES`（未設定時為空集合，維持 optional 行為）
  - `convert_coupon_data()` 跳過名稱在 `EXCLUDE_NAMES` 中的套餐主項目與可換選項（flavors）
- `src/components/ui/sheet.tsx`
  - 關閉按鈕對齊標題行、與內容右緣切齊；icon 從 `h-4` 調整為 `h-5` 與漢堡選單 icon 一致，點擊範圍也略為加大
- `index.html`
  - meta 標籤在地化與補齊

## Behavior notes

- 被排除項目完全跳過、不計入優惠券價格（與 2023 年 c99bd5a 的行為一致）。目前這些項目都是 $0，所以價格不受影響。
- 每日 quick mode 會沿用未過期的舊資料，既有項目會隨優惠券過期逐漸消失；如要立即清除可以跑一次完整收集。（截圖中的 After 為套用過濾後的資料效果示意）
- Sheet 元件目前只有 Header 的手機版選單使用（`ui/sidebar.tsx` 未被引用），不影響其他畫面。

## Test

- 以模擬 API payload 驗證 `convert_coupon_data()`：排除的主項目不出現在 `items`、保留項目中被排除的可換選項不出現在 `flavors`、價格計算不受影響
- 前端測試套件 136 項全數通過（vitest）
- 手機版選單以 Playwright 於 390×844 viewport 實測對齊

🤖 Generated with [Claude Code](https://claude.com/claude-code)
